### PR TITLE
Fix normalization on uniform weights

### DIFF
--- a/rank/ranking.go
+++ b/rank/ranking.go
@@ -62,5 +62,13 @@ func updateRanks(ranks *Rank, algorithm Algorithm) {
 }
 
 func normalize(weight float32, min float32, max float32) float32 {
-	return (weight - min) / (max - min)
+	// avoid NaN when there is only one distinct weight
+	if max != min {
+		return (weight - min) / (max - min)
+	}
+
+	if weight > 0 {
+		return 1
+	}
+	return 0
 }

--- a/rank/ranking_test.go
+++ b/rank/ranking_test.go
@@ -1,0 +1,20 @@
+package rank
+
+import (
+	"github.com/stretchr/testify/assert"
+	"math"
+	"testing"
+)
+
+func TestNormalizeSingleWord(t *testing.T) {
+	r := NewRank()
+	r.AddNewWord("hello", -1, 0)
+
+	Calculate(r, NewAlgorithmDefault())
+
+	id := r.WordValID["hello"]
+	weight := r.Words[id].Weight
+
+	assert.False(t, math.IsNaN(float64(weight)))
+	assert.Equal(t, float32(1), weight)
+}


### PR DESCRIPTION
## Summary
- prevent division by zero when all weights are equal
- add unit test covering the normalization edge case
- refactor normalize to avoid nested ifs

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/github.com/davecgh/go-spew/@v/v1.1.0.mod": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684d671191fc8321aa895c2f8eee1a53